### PR TITLE
Updated module path to match repository location

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mholt/caddy-event-exec
+module github.com/mholt/caddy-events-exec
 
 go 1.19
 


### PR DESCRIPTION
First off, thank you for your work on Caddy! I wanted to create a Caddy build with this module to give the new events system a try, but `xcaddy` errored out because there was a mismatch between the Go module path and repository location.